### PR TITLE
Allow data: img sources

### DIFF
--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration.java
@@ -40,7 +40,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 @Symbol("contentSecurityPolicyConfiguration")
 public class ContentSecurityPolicyConfiguration extends GlobalConfiguration {
 
-    public static final String DEFAULT_RULE = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'report-sample' usage.jenkins.io;";
+    public static final String DEFAULT_RULE = "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: ; script-src 'self' 'report-sample' usage.jenkins.io;";
             // Hashes for known static core scripts could be added to limit spam:
             // 'sha256-z4DDyDYJv6wQlqKsZeAc/6+Aanuong2YoqhblTEpsME=' screenResolution
             // 'sha256-z/buOmKIvbplzl42NzWxG3io200i1Ln7VCsKlSDq2qs=' var amContainer


### PR DESCRIPTION
Otherwise messages will be logged in recent Jenkinses, probably around inline SVG graphics.