### PR TITLE
Support submission of user encountering problem

### DIFF
--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyDecorator.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyDecorator.java
@@ -26,6 +26,8 @@ package io.jenkins.plugins.csp;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.PageDecorator;
+import hudson.model.User;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -58,7 +60,10 @@ public class ContentSecurityPolicyDecorator extends PageDecorator {
     }
 
     public String getValue(String rootURL) {
-        return getConfiguredRules() + "; report-uri " + rootURL + "/" + ContentSecurityPolicyRootAction.URL + "/" + getContext();
+        if (Jenkins.get().hasPermission(Jenkins.READ)) {
+            return getConfiguredRules() + "; report-uri " + rootURL + "/" + ContentSecurityPolicyRootAction.URL + "/" + getContext();
+        }
+        return getConfiguredRules();
     }
 
     private static String getContext() {
@@ -72,6 +77,7 @@ public class ContentSecurityPolicyDecorator extends PageDecorator {
         Object nearestObjectName = nearest.getObject().getClass().getName();
         String restOfUrl = nearest.getRestOfUrl();
 
-        return nearestObjectName + ":" + restOfUrl;
+        final User current = User.current();
+        return Context.encodeContext(nearestObjectName, current, restOfUrl);
     }
 }

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink.java
@@ -97,12 +97,12 @@ public class ContentSecurityPolicyManagementLink extends ManagementLink implemen
     }
 
     @Override
-    public void report(@NonNull Context context, @CheckForNull User user, @NonNull JSONObject report) {
+    public void report(@NonNull ViewContext viewContext, @CheckForNull User user, @NonNull JSONObject report) {
         final JSONObject cspReport = report.getJSONObject("csp-report");
         final String violatedDirective = cspReport.optString("violated-directive", "<UNKNOWN>");
         final String blockedUri = cspReport.optString("blocked-uri", "<UNKNOWN>");
         final String scriptSample = cspReport.optString("script-sample", "<UNKNOWN>");
-        Record record = new Record(context.getClassName(), context.getViewName(), violatedDirective, blockedUri, scriptSample, Instant.now(), user == null ? null : user.getId());
+        Record record = new Record(viewContext.getClassName(), viewContext.getViewName(), violatedDirective, blockedUri, scriptSample, Instant.now(), user == null ? null : user.getId());
         synchronized (records) {
             records.add(record);
         }

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyReceiver.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyReceiver.java
@@ -38,13 +38,13 @@ import java.util.Objects;
  */
 @Restricted(NoExternalUse.class)
 public interface ContentSecurityPolicyReceiver extends ExtensionPoint {
-    void report(@NonNull Context context, @CheckForNull User user, @NonNull JSONObject report);
+    void report(@NonNull ViewContext viewContext, @CheckForNull User user, @NonNull JSONObject report);
 
-    class Context {
+    class ViewContext {
         private final String className;
         private final String viewName;
 
-        public Context(@NonNull String className, @NonNull String viewName) {
+        public ViewContext(@NonNull String className, @NonNull String viewName) {
             this.className = Objects.requireNonNull(className, "className");
             this.viewName = Objects.requireNonNull(viewName, "viewName");
         }
@@ -71,8 +71,8 @@ public interface ContentSecurityPolicyReceiver extends ExtensionPoint {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            Context context = (Context) o;
-            return className.equals(context.className) && viewName.equals(context.viewName);
+            ViewContext viewContext = (ViewContext) o;
+            return className.equals(viewContext.className) && viewName.equals(viewContext.viewName);
         }
 
         @Override

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
@@ -70,6 +70,7 @@ public class ContentSecurityPolicyRootAction extends InvisibleAction implements 
         return URL;
     }
 
+    @SuppressWarnings({"lgtm[jenkins/csrf]", "lgtm[jenkins/missing-permission-check]"})
     public HttpResponse doDynamic(StaplerRequest req) {
         String restOfPath = StringUtils.removeStart(req.getRestOfPath(), "/");
 

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
@@ -70,7 +70,7 @@ public class ContentSecurityPolicyRootAction extends InvisibleAction implements 
         return URL;
     }
 
-    @SuppressWarnings({"lgtm[jenkins/csrf]", "lgtm[jenkins/missing-permission-check]"})
+    @SuppressWarnings({"lgtm[jenkins/csrf]", "lgtm[jenkins/no-permission-check]"})
     public HttpResponse doDynamic(StaplerRequest req) {
         String restOfPath = StringUtils.removeStart(req.getRestOfPath(), "/");
 

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.kohsuke.stapler.verb.POST;
 
 /**
  * Reporting endpoint for CSP violations.
@@ -70,7 +71,8 @@ public class ContentSecurityPolicyRootAction extends InvisibleAction implements 
         return URL;
     }
 
-    @SuppressWarnings({"lgtm[jenkins/csrf]", "lgtm[jenkins/no-permission-check]"})
+    @SuppressWarnings("lgtm[jenkins/no-permission-check]")
+    @POST
     public HttpResponse doDynamic(StaplerRequest req) {
         String restOfPath = StringUtils.removeStart(req.getRestOfPath(), "/");
 

--- a/src/main/java/io/jenkins/plugins/csp/Context.java
+++ b/src/main/java/io/jenkins/plugins/csp/Context.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2022 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.plugins.csp;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+import hudson.model.User;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import jenkins.security.HMACConfidentialKey;
+
+public class Context {
+    private static final HMACConfidentialKey KEY = new HMACConfidentialKey(Context.class, "key");
+
+    private Context() {}
+
+    private static String toBase64(String utf8) {
+        return Base64.getUrlEncoder().encodeToString(utf8.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String fromBase64(String b64) {
+        return new String(Base64.getUrlDecoder().decode(b64), StandardCharsets.UTF_8);
+    }
+
+    public static String encodeContext(@NonNull final Object ancestorName, @CheckForNull final User user, @NonNull final String restOfPath) {
+        final String userId = user == null ? "" : user.getId();
+        final String encodedContext = toBase64(userId) + ":" + toBase64(ancestorName.toString()) + ":" + toBase64(restOfPath);
+        final String mac = Base64.getUrlEncoder().encodeToString(KEY.mac(encodedContext.getBytes(StandardCharsets.UTF_8)));
+        return mac + ":" + encodedContext;
+    }
+
+    public static DecodedContext decodeContext(final String rawContext) {
+        String[] macAndContext = rawContext.split(":", 2);
+        if (macAndContext.length != 2) {
+            throw new IllegalArgumentException("Unexpected number of split entries, expected 2, got " + macAndContext.length);
+        }
+        String mac = macAndContext[0];
+        String encodedContext = macAndContext[1];
+
+        if (!KEY.checkMac(encodedContext.getBytes(StandardCharsets.UTF_8), Base64.getUrlDecoder().decode(mac))) {
+            throw new IllegalArgumentException("Mac check failed for " + encodedContext);
+        }
+
+        String[] encodedContextParts = encodedContext.split(":", 3);
+        if (encodedContextParts.length != 3) {
+            throw new IllegalArgumentException("Unexpected number of split entries, expected 3, got " + macAndContext.length);
+        }
+        return new DecodedContext(fromBase64(encodedContextParts[0]), fromBase64(encodedContextParts[1]), fromBase64(encodedContextParts[2]));
+    }
+
+    public static class DecodedContext {
+        public final String userId;
+        public final String contextClassName;
+        public final String restOfPath;
+        public DecodedContext(@CheckForNull String userId, @NonNull String contextClassName, @NonNull String restOfPath) {
+            this.userId = Util.fixEmpty(userId);
+            this.contextClassName = contextClassName;
+            this.restOfPath = restOfPath;
+        }
+    }
+}


### PR DESCRIPTION
Experimentally, the requests reporting CSP violations do not have the session cookie, so the user would always show as anonymous.

This pull request changes the reporting endpoint to an `UnprotectedRootAction`, allowing use of the reporting feature even without Overall/Read granted to anonymous users, and additionally encodes the submitting user in the URL so it can be shown on the reporting page. An HMAC is applied to all data provided by the user in the URL (user ID, ancestor class and view name) to ensure authenticity of submissions.
