### PR TITLE
Remove sidepanel

### DIFF
--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
@@ -24,13 +24,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-    <l:layout title="${it.displayName}">
-        <l:side-panel>
-            <l:tasks>
-                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
-                <l:task icon="icon-gear2 icon-md" href="${rootURL}/manage" title="${%Manage Jenkins}"/>
-            </l:tasks>
-        </l:side-panel>
+    <l:layout title="${it.displayName}" type="one-column">
         <l:main-panel>
             <h1>${%Content-Security-Policy Report}</h1>
             <p>

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
@@ -27,8 +27,8 @@ THE SOFTWARE.
     <l:layout title="${it.displayName}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="icon-up icon-md" href="${rootURL}" title="${%Back to Dashboard}"/>
-                <l:task icon="icon-gear2 icon-md" href="${rootURL}" title="${%Manage Jenkins}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-gear2 icon-md" href="${rootURL}/manage" title="${%Manage Jenkins}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>


### PR DESCRIPTION
The sidepanel links just led to the same page. This PR fixes that by removing the sidepanel entirely and switching to a `one-column` layout.