### PR TITLE
Add header at filter layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.3</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -14,7 +14,9 @@
     <properties>
         <revision>1.3</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.440.3</jenkins.version>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <name>Content Security Policy Plugin</name>

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyDecorator.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyDecorator.java
@@ -25,7 +25,7 @@ package io.jenkins.plugins.csp;
 
 import hudson.Extension;
 import hudson.model.PageDecorator;
-import hudson.model.User;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -45,7 +45,7 @@ public class ContentSecurityPolicyDecorator extends PageDecorator {
 
     private static String getContext() {
 
-        final List<Ancestor> ancestors = Stapler.getCurrentRequest().getAncestors();
+        final List<Ancestor> ancestors = Stapler.getCurrentRequest2().getAncestors();
         if (ancestors.isEmpty()) {
             // probably doesn't happen?
             return "";
@@ -54,13 +54,13 @@ public class ContentSecurityPolicyDecorator extends PageDecorator {
         Object nearestObjectName = nearest.getObject().getClass().getName();
         String restOfUrl = nearest.getRestOfUrl();
 
-        final User current = User.current();
-        return Context.encodeContext(nearestObjectName, current, restOfUrl);
+        return Context.encodeContext(nearestObjectName, Jenkins.getAuthentication2(), restOfUrl);
     }
 
     public static void setHeader() {
         // Avoiding <st:header> because that adds an additional header rather than replacing the existing one.
+        String context = getContext();
         Stapler.getCurrentResponse2()
-                .setHeader(ContentSecurityPolicyFilter.getHeader(), ContentSecurityPolicyFilter.getValue(getContext()));
+                .setHeader(ContentSecurityPolicyFilter.getHeader(), ContentSecurityPolicyFilter.getValue(context));
     }
 }

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
@@ -80,7 +80,11 @@ public class ContentSecurityPolicyFilter implements HttpServletFilter {
              * Set the header without a context at this low layer. We later attempt to add context information in
              * ContentSecurityPolicyDecorator.
              */
-            rsp.setHeader(header, getValue(null));
+            String context = Context.encodeContext(
+                    ContentSecurityPolicyFilter.class.getName(),
+                    Jenkins.getAuthentication2(),
+                    StringUtils.removeStart(req.getRequestURI(), req.getContextPath()));
+            rsp.setHeader(header, getValue(context));
         }
         return false;
     }

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.plugins.csp;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jenkins.model.Jenkins;
+import jenkins.util.HttpServletFilter;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Inject the CSP header based on {@link ContentSecurityPolicyConfiguration} into Jenkins views.
+ * The reporting URL is implemented by {@link ContentSecurityPolicyRootAction}.
+ * At the {@link Filter} level, {@link Context} is not available.
+ * We later attempt to add {@link Context} information in {@link ContentSecurityPolicyDecorator}.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class ContentSecurityPolicyFilter implements HttpServletFilter {
+
+    static String getConfiguredRules() {
+        final String rule = ExtensionList.lookupSingleton(ContentSecurityPolicyConfiguration.class).getRule();
+        if (rule == null) {
+            return null;
+        }
+        return StringUtils.removeEnd(rule.trim(), ";");
+    }
+
+    static String getHeader() {
+        final boolean reportOnly = ExtensionList.lookupSingleton(ContentSecurityPolicyConfiguration.class).isReportOnly();
+        return reportOnly ? "Content-Security-Policy-Report-Only" : "Content-Security-Policy";
+    }
+
+    static String getValue(@CheckForNull String context) {
+        if (context != null) {
+            final Jenkins jenkins = Jenkins.getInstanceOrNull();
+            if (jenkins != null) {
+                final String rootUrl = jenkins.getRootUrl();
+                if (rootUrl != null && jenkins.hasPermission(Jenkins.READ)) {
+                    return getConfiguredRules() + "; report-uri " + rootUrl + "/" + ContentSecurityPolicyRootAction.URL
+                            + "/" + context;
+                }
+            }
+        }
+        return getConfiguredRules();
+    }
+
+    @Override
+    public boolean handle(HttpServletRequest req, HttpServletResponse rsp) {
+        final String header = getHeader();
+        if (rsp.getHeader(header) == null) {
+            /*
+             * Set the header without a context at this low layer. We later attempt to add context information in
+             * ContentSecurityPolicyDecorator.
+             */
+            rsp.setHeader(header, getValue(null));
+        }
+        return false;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
@@ -42,6 +42,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest2;
+import org.springframework.security.core.Authentication;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -56,7 +57,7 @@ import org.kohsuke.stapler.verb.POST;
  * URL for that.
  * <p>
  * While this is an {@link hudson.model.UnprotectedRootAction}, only submissions with correct HMAC
- * from {@link Context#encodeContext(Object, hudson.model.User, String)} will be accepted.
+ * from {@link Context#encodeContext(Object, Authentication, String)} will be accepted.
  */
 @Extension
 @Restricted(NoExternalUse.class)

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
@@ -30,6 +30,10 @@ import hudson.model.UnprotectedRootAction;
 import hudson.model.User;
 import hudson.security.csrf.CrumbExclusion;
 import hudson.util.HttpResponses;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -37,12 +41,8 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.logging.Level;
@@ -51,7 +51,7 @@ import org.kohsuke.stapler.verb.POST;
 
 /**
  * Reporting endpoint for CSP violations.
- * {@link StaplerRequest#getRestOfPath()} is used to associate violations with
+ * {@link StaplerRequest2#getRestOfPath()} is used to associate violations with
  * the view they occur in; {@link ContentSecurityPolicyDecorator} needs to have a dynamic report
  * URL for that.
  * <p>
@@ -73,7 +73,7 @@ public class ContentSecurityPolicyRootAction extends InvisibleAction implements 
 
     @SuppressWarnings("lgtm[jenkins/no-permission-check]")
     @POST
-    public HttpResponse doDynamic(StaplerRequest req) {
+    public HttpResponse doDynamic(StaplerRequest2 req) {
         String restOfPath = StringUtils.removeStart(req.getRestOfPath(), "/");
 
         try {

--- a/src/main/java/io/jenkins/plugins/csp/Context.java
+++ b/src/main/java/io/jenkins/plugins/csp/Context.java
@@ -26,10 +26,10 @@ package io.jenkins.plugins.csp;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
-import hudson.model.User;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import jenkins.security.HMACConfidentialKey;
+import org.springframework.security.core.Authentication;
 
 public class Context {
     private static final HMACConfidentialKey KEY = new HMACConfidentialKey(Context.class, "key");
@@ -44,8 +44,11 @@ public class Context {
         return new String(Base64.getUrlDecoder().decode(b64), StandardCharsets.UTF_8);
     }
 
-    public static String encodeContext(@NonNull final Object ancestorName, @CheckForNull final User user, @NonNull final String restOfPath) {
-        final String userId = user == null ? "" : user.getId();
+    public static String encodeContext(
+            @NonNull final Object ancestorName,
+            @CheckForNull final Authentication authentication,
+            @NonNull final String restOfPath) {
+        final String userId = authentication == null ? "" : authentication.getName();
         final String encodedContext = toBase64(userId) + ":" + toBase64(ancestorName.toString()) + ":" + toBase64(restOfPath);
         final String mac = Base64.getUrlEncoder().encodeToString(KEY.mac(encodedContext.getBytes(StandardCharsets.UTF_8)));
         return mac + ":" + encodedContext;

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyDecorator/httpHeaders.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyDecorator/httpHeaders.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-    <st:header name="${it.getHeader()}" value="${it.getValue(rootURL)}" />
+    <j:invokeStatic className="io.jenkins.plugins.csp.ContentSecurityPolicyDecorator" method="setHeader"/>
 </j:jelly>


### PR DESCRIPTION
### Problem

While working on Blue Ocean CSP compatibility recently, I discovered that the CSP plugin does not add the CSP header to Blue Ocean pages.

### Solution

This PR addresses the issue by adding the CSP header at the filter layer. At the filter layer, the `StaplerRequest` is not yet initialized, so we cannot populate the context for reporting purposes. So we retain the existing `PageDecorator` for the purposes of filling in the context. So before this PR, we set the header with proper context but only for some pages. After this PR, we always set the header, but only with proper context for some pages. This is a strict improvement over the status quo, as the existing status quo is retained with this PR with the additional benefit of adding the header (without context) for additional pages. Adding the header without context isn't great for debugging purposes, but it is effective at enforcing CSP for security purposes.

### Implementation

The use of `HttpServletFilter` necessitated a core bump to 2.479.1 LTS.

### Future work

A future improvement to this PR could try to create a minimal context at the filter layer that includes just the URL without information about Stapler ancestor objects. I am not sure if the current user is initialized at this layer, but it would be worth trying to add that as well.

### Testing done

- Verified that Blue Ocean erroneously loaded when in CSP restrictive mode before this PR and before my Blue Ocean fixes.
- Verified that Blue Ocean correctly failed to load when in CSP restrictive mode after this PR and before my Blue Ocean fixes.
- Verified that Blue Ocean correct loaded when in CSP restrictive mode after this PR and after my Blue Ocean fixes.
- Verified that the context was still present as before when loading normal pages.
- Verified that the Blue Ocean pages at least had the CSP header, even if they did not have context.
- Verified in a debugger that setting the CSP header in `DirectoryBrowserSupport`, `FormFieldValidator`, and `FormValidation` worked as before this PR. That is, this PR sets the header at the filter layer, but those three classes override it correctly, resulting in the same header being ultimately sent out as before this PR.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
