### PR TITLE
Skip setting CSP header on resource root URL request

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,13 @@ A new link _Content Security Policy Reports_ on the _Manage Jenkins_ page allows
 
 Rules can be configured on the _Configure Global Security_ configuration screen.
 
+This plugin serves Content-Security-Policy headers for all HTTP responses, including user-generated content (files in workspaces, archived artifacts, etc.), unless those are served from the https://www.jenkins.io/doc/book/security/user-content/#resource-root-url[Resource Root URL].
+This interacts with the https://www.jenkins.io/doc/book/security/configuring-content-security-policy/[default Content-Security-Policy headers set by Jenkins since 1.641 and LTS 1.625.3 for these resources] as follows:
+
+* If this plugin is configured to only report violations (the default), both enforcing (from Jenkins) and non-enforcing (from this plugin) headers will be set.
+* If this plugin is configured to enforce rules, Jenkins's Content-Security-Policy headers for these resources take precedence over this plugin's.
+* If the `hudson.model.DirectoryBrowserSupport.CSP` Java system property is set to the empty string (i.e., disable default protection from Jenkins), this plugin will still set the enforcing header if configured to do so.
+
 == Issues
 
 Report issues and enhancements in the https://www.jenkins.io/participate/report-issue/redirect/#28623[Jenkins issue tracker].

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,16 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>access-modifier-suppressions</artifactId>
-            <version>1.33</version>
+            <version>${access-modifier-checker.version}</version>
+            <!-- Not needed at runtime -->
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- Upper bounds and comes from core -->
+                    <groupId>org.kohsuke</groupId>
+                    <artifactId>access-modifier-annotation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>ionicons-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-suppressions</artifactId>
+            <version>1.33</version>
+        </dependency>
     </dependencies>
 
     <licenses>

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
@@ -30,10 +30,12 @@ import jakarta.servlet.Filter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
+import jenkins.security.ResourceDomainConfiguration;
 import jenkins.util.HttpServletFilter;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
 /**
  * Inject the CSP header based on {@link ContentSecurityPolicyConfiguration} into Jenkins views.
@@ -72,10 +74,11 @@ public class ContentSecurityPolicyFilter implements HttpServletFilter {
         return getConfiguredRules();
     }
 
+    @SuppressRestrictedWarnings({ResourceDomainConfiguration.class})
     @Override
     public boolean handle(HttpServletRequest req, HttpServletResponse rsp) {
         final String header = getHeader();
-        if (rsp.getHeader(header) == null) {
+        if (rsp.getHeader(header) == null && !ResourceDomainConfiguration.isResourceRequest(req)) {
             /*
              * Set the header without a context at this low layer. We later attempt to add context information in
              * ContentSecurityPolicyDecorator.

--- a/src/test/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilterTest.java
@@ -1,0 +1,133 @@
+package io.jenkins.plugins.csp;
+
+import hudson.ExtensionList;
+import hudson.model.DirectoryBrowserSupport;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import jenkins.security.ResourceDomainConfiguration;
+import org.htmlunit.Page;
+import org.htmlunit.WebResponse;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.util.NameValuePair;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
+import org.xml.sax.SAXException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ContentSecurityPolicyFilterTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testRegularPageHeaders() throws IOException, SAXException {
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            final HtmlPage htmlPage = wc.goTo("userContent/");
+            assertThat(htmlPage.getWebResponse().getStatusCode(), is(200));
+            final List<NameValuePair> cspHeaders = htmlPage.getWebResponse().getResponseHeaders().stream().filter(p -> p.getName().startsWith(CONTENT_SECURITY_POLICY_HEADER)).collect(Collectors.toList());
+            assertThat(cspHeaders.size(), is(1));
+            assertThat(cspHeaders.get(0).getValue(), startsWith(ContentSecurityPolicyConfiguration.DEFAULT_RULE));
+        }
+    }
+
+    @Test
+    public void testBundledResource() throws IOException, SAXException {
+        try (JenkinsRule.WebClient wc = j.createWebClient().withThrowExceptionOnFailingStatusCode(false)) {
+            final Page page = wc.goTo("apple-touch-icon.png", "image/png");
+            assertThat(page.getWebResponse().getStatusCode(), is(200));
+            final List<NameValuePair> cspHeaders = page.getWebResponse().getResponseHeaders().stream().filter(p -> p.getName().startsWith(CONTENT_SECURITY_POLICY_HEADER)).collect(Collectors.toList());
+            assertThat(cspHeaders.size(), is(1));
+            assertThat(cspHeaders.get(0).getValue(), startsWith(ContentSecurityPolicyConfiguration.DEFAULT_RULE));
+        }
+    }
+
+    @Test
+    public void test404ErrorHeaders() throws IOException, SAXException {
+        try (JenkinsRule.WebClient wc = j.createWebClient().withThrowExceptionOnFailingStatusCode(false)) {
+            final HtmlPage htmlPage = wc.goTo("thisUrlDoesNotExist");
+            assertThat(htmlPage.getWebResponse().getStatusCode(), is(404));
+            final List<NameValuePair> cspHeaders = htmlPage.getWebResponse().getResponseHeaders().stream().filter(p -> p.getName().startsWith(CONTENT_SECURITY_POLICY_HEADER)).collect(Collectors.toList());
+            assertThat(cspHeaders.size(), is(1));
+            assertThat(cspHeaders.get(0).getValue(), startsWith(ContentSecurityPolicyConfiguration.DEFAULT_RULE));
+        }
+    }
+
+    @SuppressRestrictedWarnings({DirectoryBrowserSupport.class})
+    @Test
+    public void directoryBrowserSupportContradictsCspPluginWithReporting() throws IOException, SAXException {
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            final Page page = wc.goTo("userContent/readme.txt", "text/plain");
+            assertThat(page.getWebResponse().getStatusCode(), is(200));
+            final Map<String, String> cspHeaders = getCspResponseHeadersMap(page.getWebResponse());
+            assertThat(cspHeaders.size(), is(CSP_HEADERS.size()));
+            assertThat(cspHeaders.get(CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER), startsWith(ContentSecurityPolicyConfiguration.DEFAULT_RULE));
+            assertThat(cspHeaders.get(CONTENT_SECURITY_POLICY_HEADER), equalTo(DirectoryBrowserSupport.DEFAULT_CSP_VALUE));
+        }
+    }
+
+    @SuppressRestrictedWarnings({DirectoryBrowserSupport.class})
+    @Test
+    public void directoryBrowserSupportWinsOverCspPluginWithEnforcing() throws IOException, SAXException {
+        ExtensionList.lookupSingleton(ContentSecurityPolicyConfiguration.class).setReportOnly(false);
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            final Page htmlPage = wc.goTo("userContent/readme.txt", "text/plain");
+            assertThat(htmlPage.getWebResponse().getStatusCode(), is(200));
+            final Map<String, String> cspHeaders = getCspResponseHeadersMap(htmlPage.getWebResponse());
+            assertThat(cspHeaders.size(), is(DBS_AND_ENFORCING_CSP_HEADERS.size()));
+            assertThat(cspHeaders.get(CONTENT_SECURITY_POLICY_HEADER), equalTo(DirectoryBrowserSupport.DEFAULT_CSP_VALUE));
+        }
+    }
+
+    @Test
+    public void resourceDomainHasNoHeaderWithReporting() throws IOException, SAXException {
+        ResourceDomainConfiguration.get().setUrl(j.getURL().toExternalForm().replace("localhost", "127.0.0.1")); // TODO ugh
+        try (JenkinsRule.WebClient wc = j.createWebClient().withRedirectEnabled(true)) {
+            final Page htmlPage = wc.goTo("userContent/readme.txt", "text/plain");
+            assertThat(htmlPage.getWebResponse().getStatusCode(), is(200));
+            final Map<String, String> cspHeaders = getCspResponseHeadersMap(htmlPage.getWebResponse());
+            assertThat(cspHeaders.size(), is(0));
+        }
+    }
+
+    @Test
+    public void resourceDomainHasNoHeaderWithEnforcing() throws IOException, SAXException {
+        ResourceDomainConfiguration.get().setUrl(j.getURL().toExternalForm().replace("localhost", "127.0.0.1")); // TODO ugh
+        ExtensionList.lookupSingleton(ContentSecurityPolicyConfiguration.class).setReportOnly(false);
+        try (JenkinsRule.WebClient wc = j.createWebClient().withRedirectEnabled(true)) {
+            final Page htmlPage = wc.goTo("userContent/readme.txt", "text/plain");
+            assertThat(htmlPage.getWebResponse().getStatusCode(), is(200));
+            final Map<String, String> cspHeaders = getCspResponseHeadersMap(htmlPage.getWebResponse());
+            assertThat(cspHeaders.size(), is(0));
+        }
+    }
+
+    private static Map<String, String> getResponseHeadersMap(WebResponse response) {
+        return response
+                .getResponseHeaders()
+                .stream()
+                .map(pair -> Map.entry(pair.getName(), pair.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static Map<String, String> getCspResponseHeadersMap(WebResponse response) {
+        return getResponseHeadersMap(response)
+                .entrySet()
+                .stream()
+                .filter(entry -> CSP_HEADERS.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
+    private static final String CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER = "Content-Security-Policy-Report-Only";
+    private static final String X_WEBKIT_CSP_HEADER = "X-WebKit-CSP";
+    private static final String X_CONTENT_SECURITY_POLICY_HEADER = "X-Content-Security-Policy";
+    private static final List<String> CSP_HEADERS = List.of(CONTENT_SECURITY_POLICY_HEADER, X_WEBKIT_CSP_HEADER, X_CONTENT_SECURITY_POLICY_HEADER, CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER);
+    private static final List<String> DBS_AND_ENFORCING_CSP_HEADERS = List.of(CONTENT_SECURITY_POLICY_HEADER, X_WEBKIT_CSP_HEADER, X_CONTENT_SECURITY_POLICY_HEADER);
+}

--- a/src/test/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilterTest.java
@@ -118,7 +118,7 @@ public class ContentSecurityPolicyFilterTest {
 
     @Test
     public void resourceDomainHasNoHeaderWithReporting() throws IOException, SAXException {
-        ResourceDomainConfiguration.get().setUrl(j.getURL().toExternalForm().replace("localhost", "127.0.0.1")); // TODO ugh
+        ResourceDomainConfiguration.get().setUrl(j.getURL().toExternalForm().replace("localhost", RRURL_HOSTNAME));
         try (JenkinsRule.WebClient wc = j.createWebClient().withRedirectEnabled(true)) {
             final Page htmlPage = wc.goTo("userContent/readme.txt", "text/plain");
             assertThat(htmlPage.getWebResponse().getStatusCode(), is(200));
@@ -129,7 +129,7 @@ public class ContentSecurityPolicyFilterTest {
 
     @Test
     public void resourceDomainHasNoHeaderWithEnforcing() throws IOException, SAXException {
-        ResourceDomainConfiguration.get().setUrl(j.getURL().toExternalForm().replace("localhost", "127.0.0.1")); // TODO ugh
+        ResourceDomainConfiguration.get().setUrl(j.getURL().toExternalForm().replace("localhost", RRURL_HOSTNAME));
         ExtensionList.lookupSingleton(ContentSecurityPolicyConfiguration.class).setReportOnly(false);
         try (JenkinsRule.WebClient wc = j.createWebClient().withRedirectEnabled(true)) {
             final Page htmlPage = wc.goTo("userContent/readme.txt", "text/plain");
@@ -155,6 +155,8 @@ public class ContentSecurityPolicyFilterTest {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
+    // https://github.com/jenkinsci/jenkins/blob/b8e5141a9e69318d908982eaecdfea798010f954/test/src/test/java/jenkins/security/ResourceDomainTest.java#L45-L53
+    public static final String RRURL_HOSTNAME = "127.0.0.1";
     private static final String DBS_CSP_SYSTEM_PROPERTY = "hudson.model.DirectoryBrowserSupport.CSP";
     private static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
     private static final String CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER = "Content-Security-Policy-Report-Only";


### PR DESCRIPTION
Since https://github.com/jenkinsci/csp-plugin/pull/18, CSP headers are also set for files served by `DirectoryBrowserSupport` from "Resource Root URL" requests when that shouldn't be the case.

This probably still clashes in some way with `hudson.model.DirectoryBrowserSupport.CSP`, TBD exactly (but that seems like a reasonable tradeoff, just needs to be documented).

### Testing done

Freestyle job with shell build step `echo '<script>alert(1)</script>' > index.html`. Navigate to the file in the workspace browser. With RRURL set, the script executes (as intended, was regressed), otherwise does not (as intended).

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
