### PR TITLE
Add special case for unknown Stapler context class

### DIFF
--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
@@ -84,7 +84,7 @@ public class ContentSecurityPolicyFilter implements HttpServletFilter {
              * ContentSecurityPolicyDecorator.
              */
             String context = Context.encodeContext(
-                    ContentSecurityPolicyFilter.class.getName(),
+                    "",
                     Jenkins.getAuthentication2(),
                     StringUtils.removeStart(req.getRequestURI(), req.getContextPath()));
             rsp.setHeader(header, getValue(context));

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink.java
@@ -194,6 +194,9 @@ public class ContentSecurityPolicyManagementLink extends ManagementLink implemen
         }
 
         public PluginWrapper getContextPlugin() {
+            if (contextClassName.isEmpty()) {
+                return null;
+            }
             try {
                 final PluginManager pluginManager = Jenkins.get().getPluginManager();
                 return pluginManager.whichPlugin(pluginManager.uberClassLoader.loadClass(this.contextClassName));

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
@@ -71,7 +71,14 @@ THE SOFTWARE.
                                     <j:set var="plugin" value="${record.contextPlugin}"/>
                                     <j:choose>
                                         <j:when test="${plugin == null}">
-                                            ${%contextWithoutPlugin(record.contextClassName)}
+                                            <j:choose>
+                                                <j:when test="${empty(record.contextClassName)}">
+                                                    <em>(context class unknown)</em>
+                                                </j:when>
+                                                <j:otherwise>
+                                                    ${%contextWithoutPlugin(record.contextClassName)}
+                                                </j:otherwise>
+                                            </j:choose>
                                         </j:when>
                                         <j:otherwise>
                                             ${%contextWithPlugin(record.contextClassName, plugin.url, plugin.displayName)}


### PR DESCRIPTION
From https://github.com/jenkinsci/csp-plugin/pull/18#issuecomment-2488124088 this addresses:

> The CSP Plugin being the culprit is a little awkward (could special-case this one to show no ancestor), but otherwise this seems reasonable.

Now:

> <img width="1841" alt="Screenshot 2024-11-20 at 21 01 09" src="https://github.com/user-attachments/assets/3a9f103d-bb58-4612-b2ab-865447577db1">


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
