### PR TITLE
Copyedit documentation and user-visible strings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ This plugin serves Content Security Policy headers for all HTTP responses, inclu
 This interacts with the https://www.jenkins.io/doc/book/security/configuring-content-security-policy/[default Content Security Policy headers set by Jenkins since 1.641 and LTS 1.625.3 for these resources] as follows:
 
 * If this plugin is configured to only report violations (the default), both enforcing (from Jenkins) and non-enforcing (from this plugin) headers will be set.
-* If this plugin is configured to enforce rules, Jenkins's Content Security Policy headers for these resources take precedence over this plugin's.
+* If this plugin is configured to enforce rules, Jenkins's Content-Security-Policy header for these resources takes precedence over this plugin's.
 * If the `hudson.model.DirectoryBrowserSupport.CSP` Java system property is set to the empty string (i.e., disable default protection from Jenkins), this plugin will still set the enforcing header if configured to do so.
 
 == Issues

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ This plugin serves Content Security Policy headers for all HTTP responses, inclu
 This interacts with the https://www.jenkins.io/doc/book/security/configuring-content-security-policy/[default Content Security Policy headers set by Jenkins since 1.641 and LTS 1.625.3 for these resources] as follows:
 
 * If this plugin is configured to only report violations (the default), both enforcing (from Jenkins) and non-enforcing (from this plugin) headers will be set.
-* If this plugin is configured to enforce rules, Jenkins's Content-Security-Policy header for these resources takes precedence over this plugin's.
+* If this plugin is configured to enforce rules, Jenkins's `Content-Security-Policy` header for these resources takes precedence over this plugin's.
 * If the `hudson.model.DirectoryBrowserSupport.CSP` Java system property is set to the empty string (i.e., disable default protection from Jenkins), this plugin will still set the enforcing header if configured to do so.
 
 == Issues

--- a/README.adoc
+++ b/README.adoc
@@ -1,25 +1,27 @@
 = Content Security Policy Plugin
 
-WARNING: Jenkins is currently (version 2.390) not ready for this plugin to be used to enforce Content-Security-Policy for most resources in production environments.
-Many features, both in core and plugins, will stop working with the default rule set.
-At this time, this plugin is a utility for Jenkins developers, not for Jenkins administrators.
+WARNING: Jenkins is currently (version 2.485) not ready for this plugin to be used to enforce Content Security Policy for all production environments.
+Some features will stop working with the default rule set when _Report Only_ is unchecked.
+See https://issues.jenkins.io/browse/JENKINS-60865[JENKINS-60865] to track plugin compatibility.
 
 == Introduction
 
-This plugin implements Content-Security-Policy protection for the classic Jenkins UI.
+This plugin implements Content Security Policy protection for Jenkins.
 
 == Getting started
 
-Install this plugin to have basic reporting of Content-Security-Policy violations in Jenkins:
+Install this plugin to have basic reporting of Content Security Policy violations in Jenkins:
 A new link _Content Security Policy Reports_ on the _Manage Jenkins_ page allows administrators to review reported policy violations.
 
 Rules can be configured on the _Configure Global Security_ configuration screen.
+By default, Content Security Policy violations are reported but not enforced.
+To enforce Content Security Policy, uncheck _Report Only_ on the _Configure Global Security_ configuration screen.
 
-This plugin serves Content-Security-Policy headers for all HTTP responses, including user-generated content (files in workspaces, archived artifacts, etc.), unless those are served from the https://www.jenkins.io/doc/book/security/user-content/#resource-root-url[Resource Root URL].
-This interacts with the https://www.jenkins.io/doc/book/security/configuring-content-security-policy/[default Content-Security-Policy headers set by Jenkins since 1.641 and LTS 1.625.3 for these resources] as follows:
+This plugin serves Content Security Policy headers for all HTTP responses, including user-generated content (files in workspaces, archived artifacts, etc.), unless those are served from the https://www.jenkins.io/doc/book/security/user-content/#resource-root-url[Resource Root URL].
+This interacts with the https://www.jenkins.io/doc/book/security/configuring-content-security-policy/[default Content Security Policy headers set by Jenkins since 1.641 and LTS 1.625.3 for these resources] as follows:
 
 * If this plugin is configured to only report violations (the default), both enforcing (from Jenkins) and non-enforcing (from this plugin) headers will be set.
-* If this plugin is configured to enforce rules, Jenkins's Content-Security-Policy headers for these resources take precedence over this plugin's.
+* If this plugin is configured to enforce rules, Jenkins's Content Security Policy headers for these resources take precedence over this plugin's.
 * If the `hudson.model.DirectoryBrowserSupport.CSP` Java system property is set to the empty string (i.e., disable default protection from Jenkins), this plugin will still set the enforcing header if configured to do so.
 
 == Issues

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration.java
@@ -34,7 +34,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundSetter;
 
 /**
- * Customize the Content-Security-Policy rules.
+ * Customize the Content Security Policy rules.
  */
 @Extension
 @Restricted(NoExternalUse.class)

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink.java
@@ -82,7 +82,7 @@ public class ContentSecurityPolicyManagementLink extends ManagementLink implemen
 
     @Override
     public String getDescription() {
-        return "Review reported Content-Security-Policy violations."; // TODO i18n
+        return "Review reported Content Security Policy violations."; // TODO i18n
     }
 
     @NonNull

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyReceiver.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyReceiver.java
@@ -34,7 +34,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import java.util.Objects;
 
 /**
- * Extension point for receivers of Content-Security-Policy reports.
+ * Extension point for receivers of Content Security Policy reports.
  */
 @Restricted(NoExternalUse.class)
 public interface ContentSecurityPolicyReceiver extends ExtensionPoint {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    This plugin implements Content-Security-Policy protection for the classic Jenkins UI.
+    This plugin implements Content Security Policy protection for Jenkins.
 </div>

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration/help-reportOnly.html
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration/help-reportOnly.html
@@ -1,3 +1,3 @@
 <div>
-    If this is checked, Content-Security-Policy violations will still be reported, but they will not be enforced.
+    If this is checked, Content Security Policy violations will still be reported, but they will not be enforced.
 </div>

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration/help-rule.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration/help-rule.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <div>
-        This is the actual Content-Security-Policy rule being applied to most pages served by Jenkins.
+        This is the actual Content Security Policy rule being applied to most pages served by Jenkins.
         The default value for this is:
         <code>
             <pre>
@@ -33,6 +33,6 @@ THE SOFTWARE.
             </pre>
         </code>
         Do not add <code>report-uri</code> here.
-        Jenkins dynamically determines the <code>report-uri</code> directive for each page visited to allow associating problems with views and adds it to the Content-Security-Policy header.
+        Jenkins dynamically determines the <code>report-uri</code> directive for each page visited to allow associating problems with views and adds it to the Content Security Policy header.
     </div>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration/help-rule.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyConfiguration/help-rule.jelly
@@ -33,6 +33,6 @@ THE SOFTWARE.
             </pre>
         </code>
         Do not add <code>report-uri</code> here.
-        Jenkins dynamically determines the <code>report-uri</code> directive for each page visited to allow associating problems with views and adds it to the Content Security Policy header.
+        Jenkins dynamically determines the <code>report-uri</code> directive for each page visited to allow associating problems with views and adds it to the <code>Content-Security-Policy</code> header.
     </div>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <l:layout title="${it.displayName}" type="one-column">
         <l:main-panel>
-            <h1>${%Content-Security-Policy Report}</h1>
+            <h1>${%Content Security Policy Report}</h1>
             <p>
                 ${%blurb}
             </p>

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.properties
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.properties
@@ -20,10 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-blurb = This page contains a list of recently reported Content-Security-Policy violations to help administrators identify plugins incompatible with the configured Content-Security-Policy.
-blurb2 = Context Class and Context View identify what kind of page contained content violating the current Content-Security-Policy. \
+blurb = This page contains a list of recently reported Content Security Policy violations to help administrators identify plugins incompatible with the configured Content Security Policy.
+blurb2 = Context Class and Context View identify what kind of page contained content violating the current Content Security Policy. \
   Note that the context (including possibly plugins) identified on this page are what define the affected pages. \
   Other plugins, or even Jenkins core features, may be contributing the offending feature to those pages through extension points.
-configure = You can customize the Content-Security-Policy rules <a href="{0}/configureSecurity/">in the Global Security Configuration</a>.
+configure = You can customize the Content Security Policy rules <a href="{0}/configureSecurity/">in the Global Security Configuration</a>.
 contextWithPlugin = {0} (<a href="{1}" target="_blank" rel="noopener noreferrer">{2}</a>)
 contextWithoutPlugin = {0}


### PR DESCRIPTION
Removing hyphens from "Content Security Policy" unless the context is a header (e.g., the `Content-Security-Policy` header).