### PR TITLE
Add administrative monitor

### DIFF
--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor.java
@@ -1,0 +1,66 @@
+package io.jenkins.plugins.csp;
+
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.model.AdministrativeMonitor;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class ContentSecurityPolicyAdministrativeMonitor extends AdministrativeMonitor {
+
+    @Override
+    public String getDisplayName() {
+        return Messages.ContentSecurityPolicyAdministrativeMonitor_DisplayName();
+    }
+
+    @Override
+    public boolean isActivated() {
+        return isDisableReportOnly() || isEnableReportOnly();
+    }
+
+    public boolean isEnableReportOnly() {
+        ContentSecurityPolicyConfiguration configuration =
+                ExtensionList.lookupSingleton(ContentSecurityPolicyConfiguration.class);
+        ContentSecurityPolicyManagementLink managementLink =
+                ExtensionList.lookupSingleton(ContentSecurityPolicyManagementLink.class);
+        return !configuration.isReportOnly() && !managementLink.getRecords().isEmpty();
+    }
+
+    public boolean isDisableReportOnly() {
+        ContentSecurityPolicyConfiguration configuration =
+                ExtensionList.lookupSingleton(ContentSecurityPolicyConfiguration.class);
+        ContentSecurityPolicyManagementLink managementLink =
+                ExtensionList.lookupSingleton(ContentSecurityPolicyManagementLink.class);
+        return configuration.isReportOnly()
+                && managementLink.getRecords().isEmpty()
+                && Duration.between(managementLink.getStart(), Instant.now()).compareTo(Duration.ofHours(ContentSecurityPolicyManagementLink.ROTATE_PERIOD_HOURS)) > 0;
+    }
+
+    @Override
+    public boolean isSecurity() {
+        return true;
+    }
+
+    @RequirePOST
+    public HttpResponse doAct(@QueryParameter String dismiss) throws IOException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        if (dismiss != null) {
+            disable(true);
+        } else {
+            ContentSecurityPolicyConfiguration configuration =
+                    ExtensionList.lookupSingleton(ContentSecurityPolicyConfiguration.class);
+            configuration.setReportOnly(!configuration.isReportOnly());
+        }
+        return HttpResponses.forwardToPreviousPage();
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor/description.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+  ${%blurb}
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor/description.properties
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Recommends that administrators toggle Content Security Policy Report Only mode on or off based on the presence or absence of violations.

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor/message.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor/message.jelly
@@ -1,0 +1,26 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
+  <div class="jenkins-alert jenkins-alert-${it.enableReportOnly ? 'warning' : 'info'}">
+    <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
+      <l:isAdmin>
+        <j:choose>
+          <j:when test="${it.enableReportOnly}">
+            <f:submit name="toggle" value="${%Report Only}"/>
+          </j:when>
+          <j:otherwise>
+            <f:submit name="toggle" value="${%Enforce CSP}"/>
+          </j:otherwise>
+        </j:choose>
+        <f:submit name="dismiss" value="${%Dismiss}"/>
+      </l:isAdmin>
+    </form>
+    <j:choose>
+      <j:when test="${it.enableReportOnly}">
+        <div>${%enableReportOnly}</div>
+      </j:when>
+      <j:otherwise>
+        <div>${%disableReportOnly}</div>
+      </j:otherwise>
+    </j:choose>
+  </div>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor/message.properties
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyAdministrativeMonitor/message.properties
@@ -1,0 +1,2 @@
+enableReportOnly=You have enabled Content Security Policy enforcement, but there are recent Content Security Policy violations. Enable Report Only mode to disable Content Security Policy enforcement and restore functionality.
+disableReportOnly=You have disabled Content Security Policy enforcement, but there are no recent Content Security Policy violations. Enable Content Security Policy enforcement to improve the security of your controller.

--- a/src/main/resources/io/jenkins/plugins/csp/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/csp/Messages.properties
@@ -1,0 +1,1 @@
+ContentSecurityPolicyAdministrativeMonitor.DisplayName = Content Security Policy


### PR DESCRIPTION
Add an administrative monitor that encourage users to enable report-only mode if they have no recent violations and to disable report-only mode if they have recent violations.

### Testing done

Manually tested both enabling and disabling report-only mode through the monitor, as well as dismissing the monitor and re-enabling it.

I did not bother writing automated tests because at this stage we don't know if this will be the final design, and there are indications that it might very well not be.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
