### PR TITLE
Remove plugin dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <revision>1</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -22,27 +21,7 @@
     <name>Content Security Policy Plugin</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5054.v620b_5d2b_d5e6</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>ionicons-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>commons-lang3-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>access-modifier-suppressions</artifactId>

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyFilter.java
@@ -32,7 +32,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.security.ResourceDomainConfiguration;
 import jenkins.util.HttpServletFilter;
-import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
@@ -52,7 +51,7 @@ public class ContentSecurityPolicyFilter implements HttpServletFilter {
         if (rule == null) {
             return null;
         }
-        return StringUtils.removeEnd(rule.trim(), ";");
+        return removeEnd(rule.trim(), ";");
     }
 
     static String getHeader() {
@@ -84,9 +83,23 @@ public class ContentSecurityPolicyFilter implements HttpServletFilter {
             String context = Context.encodeContext(
                     "",
                     Jenkins.getAuthentication2(),
-                    StringUtils.removeStart(req.getRequestURI(), req.getContextPath()));
+                    removeStart(req.getRequestURI(), req.getContextPath()));
             rsp.setHeader(header, getValue(context));
         }
         return false;
+    }
+
+    private static String removeEnd(@NonNull String haystack, @NonNull String needle) {
+        if (haystack.endsWith(needle)) {
+            return haystack.substring(0, haystack.length() - needle.length());
+        }
+        return haystack;
+    }
+
+    private static String removeStart(@NonNull String haystack, @NonNull String needle) {
+        if (haystack.startsWith(needle)) {
+            return haystack.substring(needle.length());
+        }
+        return haystack;
     }
 }

--- a/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
+++ b/src/main/java/io/jenkins/plugins/csp/ContentSecurityPolicyRootAction.java
@@ -36,7 +36,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -75,7 +74,8 @@ public class ContentSecurityPolicyRootAction extends InvisibleAction implements 
     @SuppressWarnings("lgtm[jenkins/no-permission-check]")
     @POST
     public HttpResponse doDynamic(StaplerRequest2 req) {
-        String restOfPath = StringUtils.removeStart(req.getRestOfPath(), "/");
+        final String requestRestOfPath = req.getRestOfPath();
+        String restOfPath = requestRestOfPath.startsWith("/") ? requestRestOfPath.substring(1) : requestRestOfPath;
 
         try {
             final Context.DecodedContext context = Context.decodeContext(restOfPath);

--- a/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/csp/ContentSecurityPolicyManagementLink/index.jelly
@@ -97,7 +97,7 @@ THE SOFTWARE.
 
                 </j:when>
                 <j:otherwise>
-                    <l:notice title="${%No reports}" icon="symbol-checkmark-done-outline plugin-ionicons-api" />
+                    <l:notice title="${%No reports}" icon="symbol-check" />
                 </j:otherwise>
             </j:choose>
             <j:if test="${it.records.size() > 0}">


### PR DESCRIPTION
Both plugin dependencies are kinda unnecessary. commons-lang3 (and commons-lang before it) was only used for `removeStart`/`removeEnd`.

<details>

<summary>A single icon from ionicons with a good replacement in core also seems unnecessary.</summary>

<img width="2137" height="1336" alt="" src="https://github.com/user-attachments/assets/71b90ccc-4450-4311-ba08-e6b3af5ce26a" />

</details>


### Testing done

Visited the page with placeholder icon (above).

Triggered a CSP occurrance and confirmed it shows up.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
